### PR TITLE
use correct SVG attribute namespaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@f/foreach": "^1.2.1",
-    "is-svg-attribute": "^1.0.2",
     "is-svg-element": "^1.0.1",
+    "svg-attribute-namespace": "^1.0.0",
     "virtex": "^0.1.7"
   },
   "devDependencies": {

--- a/src/setAttribute.js
+++ b/src/setAttribute.js
@@ -34,7 +34,8 @@ function setAttribute (dispatch, node, name, value) {
         setValue(node, value)
         break
       case svg.isAttribute(name):
-        node.setAttributeNS(svg.namespace, name, value)
+        const attrNamespace = getNamespaceOfAttribute(name)
+        node.setAttributeNS(attrNamespace, name, value)
         break
       default:
         node.setAttribute(name, value)

--- a/src/svg.js
+++ b/src/svg.js
@@ -3,7 +3,7 @@
  */
 
 import {isElement} from 'is-svg-element'
-import isAttribute from 'is-svg-attribute'
+import getNamespaceOfAttribute from 'svg-attribute-namespace'
 
 /**
  * Constants
@@ -15,8 +15,13 @@ const namespace = 'http://www.w3.org/2000/svg'
  * Svg stuff
  */
 
+function isAttribute (name) {
+  return getNamespaceOfAttribute(name) !== undefined
+}
+
 export default {
   isElement,
   isAttribute,
+  getNamespaceOfAttribute,
   namespace
 }


### PR DESCRIPTION
fixes SVG attributes such as `xlink:href`.

based on https://github.com/Matt-Esch/virtual-dom/pull/172.
